### PR TITLE
fix: idempotent tag step and changeset for alpha.2

### DIFF
--- a/.changeset/fix-release-pipeline.md
+++ b/.changeset/fix-release-pipeline.md
@@ -1,0 +1,5 @@
+---
+"vmsan": patch
+---
+
+fix release pipeline: use NODE_AUTH_TOKEN for npm publish and idempotent tag step

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,10 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
+          TAG="v${VERSION}"
+          if git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi


### PR DESCRIPTION
## Summary
- Make tag step skip if tag already exists on remote (fixes the failure from PR #7)
- Add changeset to trigger version bump to `0.1.0-alpha.2`

## Expected flow after merge
1. Release workflow sees changeset → creates "Version Packages" PR (bumps to alpha.2)
2. Merge Version Packages PR → publishes `0.1.0-alpha.2` to npm
3. Tag step pushes `v0.1.0-alpha.2` → triggers agent build