### PR TITLE
fix: improve exec command UX

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -31,12 +31,9 @@ const connectCommand = defineCommand({
 
     try {
       const { state, guestIp, port } = resolveVmState(args.vmId, paths);
-      const log = consola.withTag(args.vmId);
       consola.debug(`Agent endpoint: ${guestIp}:${port}`);
-
-      log.start("Waiting for agent to become ready...");
+      consola.debug("Waiting for agent to become ready...");
       await waitForAgent(guestIp, port);
-      log.success("Agent is ready. Connecting via PTY shell...");
 
       const shell = new ShellSession({
         host: guestIp,

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -137,8 +137,7 @@ const execCommand = defineCommand({
       const { state, guestIp, port, store } = resolveVmState(args.vmId, paths);
       consola.debug(`Agent endpoint: ${guestIp}:${port}`);
 
-      const log = consola.withTag(args.vmId);
-      log.start("Waiting for agent...");
+      consola.debug(`Waiting for agent on ${guestIp}:${port}...`);
       await waitForAgent(guestIp, port);
 
       if (args.interactive) {
@@ -157,7 +156,7 @@ const execCommand = defineCommand({
         }
 
         if (args.sudo) {
-          parts.push("sudo");
+          parts.push("/usr/bin/sudo");
         }
 
         parts.push(shellEscape(command));
@@ -165,9 +164,7 @@ const execCommand = defineCommand({
           parts.push(shellEscape(a));
         }
 
-        const injectedCmd = parts.join(" ") + "; exit $?\n";
-
-        log.success("Agent is ready. Connecting interactive shell...");
+        const injectedCmd = "clear; " + parts.join(" ") + "; exit $?\n";
 
         // Wire timeout extension
         let extender: TimeoutExtender | null = null;
@@ -207,7 +204,7 @@ const execCommand = defineCommand({
 
         const agent = new AgentClient(`http://${guestIp}:${port}`, state.agentToken);
 
-        const cmd = args.sudo ? "sudo" : command;
+        const cmd = args.sudo ? "/usr/bin/sudo" : command;
         const runArgs = args.sudo ? [command, ...commandArgs] : commandArgs;
 
         const params: RunParams = {


### PR DESCRIPTION
## Summary

- Move "Waiting for agent..." messages to debug log level in `exec` and `connect` commands
- Use `clear` to hide the echoed injected command in interactive mode (`-i`)
- Use `/usr/bin/sudo` full path to fix "executable not found" error in VMs with minimal PATH

## Test plan

- [ ] `vmsan exec <vm-id> ls` runs without "Waiting for agent..." noise
- [ ] `vmsan exec <vm-id> -i ls` shows clean output without echoed PS1/command injection
- [ ] `vmsan exec <vm-id> --sudo whoami` prints "root"
- [ ] `vmsan connect <vm-id>` connects silently (no spinner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated command execution paths for improved system compatibility
  * Adjusted logging output granularity in agent connection and command operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->