### PR TITLE
docs: add exec command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ vmsan create --from-image node:22-alpine
 # List all VMs
 vmsan list
 
+# Execute a command inside a VM
+vmsan exec <vm-id> ls -la
+
+# Interactive exec with PTY
+vmsan exec -i <vm-id> bash
+
 # Connect to a running VM shell
 vmsan connect <vm-id>
 
@@ -131,16 +137,17 @@ vmsan remove <vm-id>
 
 ### Commands
 
-| Command    | Alias | Description                       |
-| ---------- | ----- | --------------------------------- |
-| `create`   |       | Create and start a new microVM    |
-| `list`     | `ls`  | List all VMs                      |
-| `start`    |       | Start a stopped VM                |
-| `stop`     |       | Stop a running VM                 |
-| `remove`   | `rm`  | Remove a VM                       |
-| `connect`  |       | Open an interactive shell to a VM |
-| `upload`   |       | Upload files to a VM              |
-| `download` |       | Download files from a VM          |
+| Command    | Alias | Description                          |
+| ---------- | ----- | ------------------------------------ |
+| `create`   |       | Create and start a new microVM       |
+| `list`     | `ls`  | List all VMs                         |
+| `start`    |       | Start a stopped VM                   |
+| `stop`     |       | Stop a running VM                    |
+| `remove`   | `rm`  | Remove a VM                          |
+| `exec`     |       | Execute a command inside a running VM |
+| `connect`  |       | Open an interactive shell to a VM    |
+| `upload`   |       | Upload files to a VM                 |
+| `download` |       | Download files from a VM             |
 
 ## Development
 

--- a/docs/content/2.guide/1.vm-lifecycle.md
+++ b/docs/content/2.guide/1.vm-lifecycle.md
@@ -74,6 +74,27 @@ Use the alias `vmsan rm` for a shorter command.
 Removing a VM deletes its chroot directory and state file permanently.
 ::
 
+## Execute commands
+
+Run a command inside a VM and stream the output:
+
+```bash
+vmsan exec <vm-id> ls -la /tmp
+```
+
+Use `-i` for interactive mode (full PTY), `--sudo` to run as root, `-w` to set the working directory, and `-e` to inject environment variables:
+
+```bash
+# Interactive session
+vmsan exec -i <vm-id> bash
+
+# Run as root
+vmsan exec --sudo <vm-id> apt-get update
+
+# With working directory and env
+vmsan exec -w /app -e NODE_ENV=production <vm-id> node server.js
+```
+
 ## Connect to a running VM
 
 Open an interactive shell session:

--- a/docs/content/3.api/1.cli-reference.md
+++ b/docs/content/3.api/1.cli-reference.md
@@ -71,6 +71,24 @@ Remove a VM and its chroot directory. Alias: `rm`.
 | -------- | -------- | ---------------- |
 | `vm-id`  | yes      | The VM to remove |
 
+### `vmsan exec`
+
+Execute a command inside a running VM.
+
+| Argument  | Required | Description                        |
+| --------- | -------- | ---------------------------------- |
+| `vm-id`   | yes      | The VM to run the command in       |
+| `command` | yes      | Command to execute, followed by args |
+
+| Flag                   | Type    | Default | Description                                     |
+| ---------------------- | ------- | ------- | ----------------------------------------------- |
+| `--sudo`               | boolean | `false` | Run as root                                     |
+| `-i`, `--interactive`  | boolean | `false` | Interactive shell mode (PTY)                    |
+| `-w`, `--workdir`      | string  | —       | Working directory inside the VM                 |
+| `-e`, `--env`          | string  | —       | Environment variable (`KEY=VAL`), repeatable    |
+| `-t`, `--tty`          | boolean | `false` | Allocate a pseudo-TTY (compatibility)           |
+| `--no-extend-timeout`  | boolean | `false` | Skip timeout extension (interactive only)       |
+
 ### `vmsan connect`
 
 Open an interactive shell to a running VM.


### PR DESCRIPTION
## Summary
- Add `vmsan exec` to CLI reference with all flags and arguments
- Add "Execute commands" section to VM lifecycle guide with usage examples
- Add `exec` to README usage examples and commands table

Closes the documentation gap from PR #26.