### PR TITLE
fix: resolve `vmsan create --connect` failing with HTTP 500

### DIFF
--- a/agent/shell/handler.go
+++ b/agent/shell/handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/gorilla/websocket"
 )
@@ -81,7 +82,11 @@ func (h *Handler) handleNewSession(w http.ResponseWriter, r *http.Request) {
 		if err.Error() == "max sessions reached" {
 			http.Error(w, `{"error":"too many concurrent sessions"}`, http.StatusTooManyRequests)
 		} else {
-			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			h.logger.Error("shell.session.create_failed", "shell", shell, "user", runAs, "error", err)
+			// Sanitize: only include the first line to avoid leaking stack traces.
+			msg := strings.SplitN(err.Error(), "\n", 2)[0]
+			encoded, _ := json.Marshal(msg)
+			http.Error(w, `{"error":`+string(encoded)+`}`, http.StatusInternalServerError)
 		}
 		return
 	}

--- a/src/lib/jailer.ts
+++ b/src/lib/jailer.ts
@@ -209,6 +209,14 @@ export class Jailer {
         );
       }
 
+      // Fix /home/ubuntu ownership so the ubuntu user (uid 1000) can access
+      // their home directory. Some base rootfs images ship /home/ubuntu owned
+      // by root:root which causes EACCES when the agent runs commands as ubuntu.
+      const ubuntuHome = join(tmpMount, "home", "ubuntu");
+      if (existsSync(ubuntuHome)) {
+        execSync(`sudo chown 1000:1000 "${ubuntuHome}"`, { stdio: "pipe" });
+      }
+
       execSync(`sudo umount "${tmpMount}"`, { stdio: "pipe" });
     } catch {
       // Mount point may already be unmounted or directory removed

--- a/src/lib/shell/client.ts
+++ b/src/lib/shell/client.ts
@@ -127,6 +127,21 @@ export class ShellSession {
         });
       });
 
+      this.ws.on("unexpected-response", (_req, res) => {
+        const maxBytes = 4096;
+        let body = "";
+        res.on("data", (chunk: Buffer) => {
+          if (body.length < maxBytes) {
+            body += chunk.toString().slice(0, maxBytes - body.length);
+          }
+        });
+        res.on("end", () => {
+          cleanup();
+          const detail = body.trim() || "no response body";
+          reject(new Error(`Shell connection failed (HTTP ${res.statusCode}): ${detail}`));
+        });
+      });
+
       this.ws.on("error", (err) => {
         cleanup();
         reject(err);


### PR DESCRIPTION
## Summary

- Fix `/home/ubuntu` ownership (root:root → 1000:1000) during rootfs injection in the jailer, preventing EACCES when the agent chdir's after setuid
- Surface actual error messages from the shell handler instead of opaque `{"error":"internal error"}`
- Handle WebSocket `unexpected-response` event in the shell client to show `Shell connection failed (HTTP 500): ...` instead of `Unexpected server response: 500`

Closes #31

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `go build ./...` — passes
- [x] `go test ./...` — passes
- [x] Tested on remote server: `vmsan create --connect` successfully opens a shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session creation failures now return detailed error messages in responses
  * Fixed directory permissions issue that prevented proper command execution
  * WebSocket connection failures now include diagnostic response details in error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->