### PR TITLE
fix: format changeset prerelease state

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,7 +4,5 @@
   "initialVersions": {
     "vmsan": "0.1.0-alpha.24"
   },
-  "changesets": [
-    "tidy-chairs-juggle"
-  ]
+  "changesets": ["tidy-chairs-juggle"]
 }


### PR DESCRIPTION
## Summary
- format  so  passes on the generated  commit
- unblock the failed CI and release-checks workflows after PR #38

## Verification
- reproduced the failure from commit 
- 
  ! eslint(no-unused-vars): Parameter 'targetCommand' is declared but never used. Unused parameters should start with a '_'.
    ,-[src/commands/exec.ts:19:24]
 18 | 
 19 | function parseEnvFlags(targetCommand: string): Record<string, string> {
    :                        ^^^^^^|^^^^^^
    :                              `-- 'targetCommand' is declared here
 20 |   const env: Record<string, string> = {};
    `----
  help: Consider removing this parameter.

  ! eslint(no-unused-vars): Variable 'hostIp' is declared but never used. Unused variables should start with a '_'.
     ,-[src/lib/network.ts:255:24]
 254 |   setupRules(): void {
 255 |     const { tapDevice, hostIp, guestIp, publishedPorts } = this.config;
     :                        ^^^|^^
     :                           `-- 'hostIp' is declared here
 256 |     const policy = effectivePolicy(this.config);
     `----
  help: Consider removing this declaration.

  ! eslint(no-unused-vars): Variable 'hostIp' is declared but never used. Unused variables should start with a '_'.
     ,-[src/lib/network.ts:665:24]
 664 |   teardownRules(): void {
 665 |     const { tapDevice, hostIp, guestIp, publishedPorts, netnsName } = this.config;
     :                        ^^^|^^
     :                           `-- 'hostIp' is declared here
 666 | 
     `----
  help: Consider removing this declaration.

Found 3 warnings and 0 errors.
Finished in 15ms on 68 files with 93 rules using 24 threads.
Checking formatting...

All matched files use the correct format.
Finished in 178ms on 73 files using 24 threads. now passes on top of  with only this formatting fix
