### PR TITLE
feat: add state file versioning

### DIFF
--- a/.changeset/state-versioning.md
+++ b/.changeset/state-versioning.md
@@ -1,0 +1,5 @@
+---
+"vmsan": minor
+---
+
+Add state file versioning to VM state store for future migration support

--- a/src/commands/create/state.ts
+++ b/src/commands/create/state.ts
@@ -1,4 +1,4 @@
-import type { VmState } from "../../lib/vm-state.ts";
+import { CURRENT_STATE_VERSION, type VmState } from "../../lib/vm-state.ts";
 import type { InitialVmStateInput } from "./types.ts";
 
 export function buildInitialVmState(input: InitialVmStateInput): VmState {
@@ -41,5 +41,6 @@ export function buildInitialVmState(input: InitialVmStateInput): VmState {
     error: null,
     agentToken: input.agentToken,
     agentPort: input.agentPort,
+    stateVersion: CURRENT_STATE_VERSION,
   };
 }

--- a/src/lib/vm-state.ts
+++ b/src/lib/vm-state.ts
@@ -1,8 +1,11 @@
 import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+import consola from "consola";
 import { vmStateNotFoundError, networkSlotsExhaustedError } from "../errors/index.ts";
 import { slotFromVmHostIpOrNull } from "./network-address.ts";
 import { mkdirSecure, writeSecure } from "./utils.ts";
+
+export const CURRENT_STATE_VERSION = 1;
 
 export interface VmNetwork {
   tapDevice: string;
@@ -43,6 +46,7 @@ export interface VmState {
   error: string | null;
   agentToken: string | null;
   agentPort: number;
+  stateVersion: number;
 }
 
 export interface VmStateStore {
@@ -83,19 +87,29 @@ export class FileVmStateStore implements VmStateStore {
 
   save(state: VmState): void {
     this.ensureDir();
+    state.stateVersion = CURRENT_STATE_VERSION;
     writeSecure(join(this.dir, `${state.id}.json`), JSON.stringify(state, null, 2));
   }
 
   load(id: string): VmState | null {
     const filePath = join(this.dir, `${id}.json`);
     if (!existsSync(filePath)) return null;
-    return JSON.parse(readFileSync(filePath, "utf-8")) as VmState;
+    const state = JSON.parse(readFileSync(filePath, "utf-8")) as VmState;
+    if (!state.stateVersion) {
+      consola.debug(`Migrated state file for VM ${id} from v0 to v1`);
+      state.stateVersion = CURRENT_STATE_VERSION;
+      this.save(state);
+    }
+    return state;
   }
 
   list(): VmState[] {
     this.ensureDir();
     const files = readdirSync(this.dir).filter((f) => f.endsWith(".json"));
-    return files.map((f) => JSON.parse(readFileSync(join(this.dir, f), "utf-8")) as VmState);
+    return files.map((f) => {
+      const id = f.replace(/\.json$/, "");
+      return this.load(id)!;
+    });
   }
 
   update(id: string, updates: Partial<VmState>): void {

--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -1,10 +1,16 @@
-import { findFreeNetworkSlot, type VmState, type VmStateStore } from "../lib/vm-state.ts";
+import {
+  CURRENT_STATE_VERSION,
+  findFreeNetworkSlot,
+  type VmState,
+  type VmStateStore,
+} from "../lib/vm-state.ts";
 import { vmStateNotFoundError } from "../errors/index.ts";
 
 export class MemoryVmStateStore implements VmStateStore {
   private states = new Map<string, VmState>();
 
   save(state: VmState): void {
+    state.stateVersion = CURRENT_STATE_VERSION;
     this.states.set(state.id, structuredClone(state));
   }
 

--- a/tests/unit/vm-state.test.ts
+++ b/tests/unit/vm-state.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { findFreeNetworkSlot } from "../../src/lib/vm-state.ts";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CURRENT_STATE_VERSION,
+  FileVmStateStore,
+  findFreeNetworkSlot,
+  type VmState,
+} from "../../src/lib/vm-state.ts";
 
 describe("findFreeNetworkSlot", () => {
   it("keeps stopped vm slots reserved for restart", () => {
@@ -36,6 +44,7 @@ describe("findFreeNetworkSlot", () => {
         error: null,
         agentToken: null,
         agentPort: 9119,
+        stateVersion: 1,
       },
       {
         id: "vm-running",
@@ -69,9 +78,101 @@ describe("findFreeNetworkSlot", () => {
         error: null,
         agentToken: null,
         agentPort: 9119,
+        stateVersion: 1,
       },
     ]);
 
     expect(slot).toBe(2);
+  });
+});
+
+function makeLegacyState(): Record<string, unknown> {
+  return {
+    id: "vm-legacy",
+    project: "",
+    runtime: "base",
+    status: "running",
+    pid: 1,
+    apiSocket: "",
+    chrootDir: "",
+    kernel: "",
+    rootfs: "",
+    vcpuCount: 1,
+    memSizeMib: 128,
+    network: {
+      tapDevice: "fhvm0",
+      hostIp: "198.19.0.1",
+      guestIp: "198.19.0.2",
+      subnetMask: "255.255.255.252",
+      macAddress: "",
+      networkPolicy: "allow-all",
+      allowedDomains: [],
+      allowedCidrs: [],
+      deniedCidrs: [],
+      publishedPorts: [],
+      tunnelHostname: null,
+    },
+    snapshot: null,
+    timeoutMs: null,
+    timeoutAt: null,
+    createdAt: "",
+    error: null,
+    agentToken: null,
+    agentPort: 9119,
+  };
+}
+
+const tempDirs: string[] = [];
+
+function makeTempStore(): FileVmStateStore {
+  const dir = mkdtempSync(join(tmpdir(), "vmsan-state-test-"));
+  tempDirs.push(dir);
+  return new FileVmStateStore(dir);
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("state file versioning", () => {
+  it("loads legacy state without version field", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vmsan-state-test-"));
+    tempDirs.push(dir);
+    const legacy = makeLegacyState();
+    writeFileSync(join(dir, "vm-legacy.json"), JSON.stringify(legacy));
+
+    const store = new FileVmStateStore(dir);
+    const state = store.load("vm-legacy");
+
+    expect(state).not.toBeNull();
+    expect(state!.id).toBe("vm-legacy");
+    expect(state!.stateVersion).toBe(CURRENT_STATE_VERSION);
+  });
+
+  it("saves state with version 1", () => {
+    const store = makeTempStore();
+    const state = { ...makeLegacyState(), stateVersion: CURRENT_STATE_VERSION } as VmState;
+    store.save(state);
+
+    const dir = tempDirs[tempDirs.length - 1];
+    const raw = JSON.parse(readFileSync(join(dir, "vm-legacy.json"), "utf-8"));
+    expect(raw.stateVersion).toBe(1);
+  });
+
+  it("auto-migrates v0 to v1", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vmsan-state-test-"));
+    tempDirs.push(dir);
+    const legacy = makeLegacyState();
+    writeFileSync(join(dir, "vm-legacy.json"), JSON.stringify(legacy));
+
+    const store = new FileVmStateStore(dir);
+    store.load("vm-legacy");
+
+    // Verify the file on disk was re-written with stateVersion
+    const raw = JSON.parse(readFileSync(join(dir, "vm-legacy.json"), "utf-8"));
+    expect(raw.stateVersion).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Add `stateVersion` field to `VmState` interface (current version: 1)
- Auto-migrate legacy alpha state files (v0 → v1) on load
- New VMs are created with `stateVersion: 1` from the start

## Changes
- `src/lib/vm-state.ts` — version field, migration logic in load(), version stamp in save()
- `src/commands/create/state.ts` — include stateVersion in buildInitialVmState()
- `src/stores/memory.ts` — stamp stateVersion in MemoryVmStateStore.save()

## Test plan
- [x] `bun run test` — 10 tests pass
- [x] `bun run lint` — clean
- [ ] Old alpha.26 state files load and auto-upgrade to v1
- [ ] New state files include `stateVersion: 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced state file versioning with automatic migration support. Legacy state files are automatically migrated to the current version when accessed, ensuring seamless compatibility and enabling future state structure updates without manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->