### PR TITLE
feat: add KVM pre-flight check and cleanup verification

### DIFF
--- a/.changeset/kvm-preflight-cleanup.md
+++ b/.changeset/kvm-preflight-cleanup.md
@@ -1,0 +1,5 @@
+---
+"vmsan": minor
+---
+
+Add KVM pre-flight check to `vmsan create` and cleanup verification after `vmsan stop`/`vmsan remove`

--- a/src/commands/create/environment.ts
+++ b/src/commands/create/environment.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync, readdirSync } from "node:fs";
 import { connect } from "node:net";
 import { join } from "node:path";
 import type { VmsanPaths } from "../../paths.ts";
@@ -10,6 +10,7 @@ import {
   noRootfsDirError,
   noExt4RootfsError,
   snapshotNotFoundError,
+  kvmUnavailableError,
 } from "../../errors/index.ts";
 import { socketTimeoutError, SetupError } from "../../errors/index.ts";
 
@@ -22,6 +23,12 @@ export function validateEnvironment(baseDir: string): void {
   }
   if (!existsSync(jailerPath)) {
     throw missingBinaryError("Jailer", jailerPath);
+  }
+
+  try {
+    accessSync("/dev/kvm", constants.R_OK | constants.W_OK);
+  } catch {
+    throw kvmUnavailableError();
   }
 }
 

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -33,7 +33,8 @@ export type SetupErrorCode =
   | "ERR_SETUP_NO_KERNEL_DIR"
   | "ERR_SETUP_NO_KERNEL"
   | "ERR_SETUP_NO_ROOTFS_DIR"
-  | "ERR_SETUP_NO_EXT4_ROOTFS";
+  | "ERR_SETUP_NO_EXT4_ROOTFS"
+  | "ERR_SETUP_KVM_UNAVAILABLE";
 
 export type CloudflareErrorCode =
   | "ERR_CLOUDFLARE_NOT_CONFIGURED"

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -60,6 +60,7 @@ export {
   noKernelError,
   noRootfsDirError,
   noExt4RootfsError,
+  kvmUnavailableError,
 } from "./setup.ts";
 
 export { handleCommandError } from "./display.ts";

--- a/src/errors/setup.ts
+++ b/src/errors/setup.ts
@@ -39,3 +39,9 @@ export const noExt4RootfsError = (): SetupError =>
     message: "No ext4 rootfs found in ~/.vmsan/rootfs/.",
     fix: INSTALL_FIX,
   });
+
+export const kvmUnavailableError = (): SetupError =>
+  new SetupError("ERR_SETUP_KVM_UNAVAILABLE", {
+    message: "/dev/kvm is not accessible — KVM virtualization is required.",
+    fix: "Ensure you're running on a KVM-capable host. Check: (1) CPU supports virtualization (grep -c vmx /proc/cpuinfo), (2) KVM module loaded (lsmod | grep kvm), (3) /dev/kvm is accessible",
+  });

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -6,6 +6,7 @@ import { toError } from "./utils.ts";
 import type { VmNetwork } from "./vm-state.ts";
 import {
   slotFromVmHostIp,
+  slotFromVmHostIpOrNull,
   vmGuestIp,
   vmHostIp,
   vmLinkCidrFromIp,
@@ -1071,4 +1072,22 @@ export class NetworkManager {
       throw err;
     }
   }
+}
+
+export function verifyCleanup(network: VmNetwork): string[] {
+  const leaks: string[] = [];
+  if (existsSync(`/sys/class/net/${network.tapDevice}`)) {
+    leaks.push(`TAP device ${network.tapDevice} still exists`);
+  }
+  if (network.netnsName && existsSync(`/var/run/netns/${network.netnsName}`)) {
+    leaks.push(`Namespace ${network.netnsName} still exists`);
+  }
+  const slot = slotFromVmHostIpOrNull(network.hostIp);
+  if (slot !== null && network.netnsName) {
+    const vethHost = `veth-h-${slot}`;
+    if (existsSync(`/sys/class/net/${vethHost}`)) {
+      leaks.push(`Veth ${vethHost} still exists`);
+    }
+  }
+  return leaks;
 }

--- a/src/services/vm.ts
+++ b/src/services/vm.ts
@@ -3,7 +3,7 @@ import { existsSync, rmSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import type { VmsanContext } from "../context.ts";
 import type { VmState, VmStateStore } from "../lib/vm-state.ts";
-import { NetworkManager, type NetworkConfig } from "../lib/network.ts";
+import { NetworkManager, verifyCleanup, type NetworkConfig } from "../lib/network.ts";
 import { FileLock } from "../lib/file-lock.ts";
 import { FirecrackerClient } from "./firecracker.ts";
 import { Jailer, type CgroupConfig, CGROUP_VMM_OVERHEAD_MIB } from "../lib/jailer.ts";
@@ -656,6 +656,11 @@ export class VMService {
           this.logger.debug(`Network teardown failed for VM ${vmId}: ${toError(err).message}`);
         }
 
+        const leaks = verifyCleanup(state.network);
+        for (const leak of leaks) {
+          this.logger.warn(`[${vmId}] cleanup leak: ${leak}`);
+        }
+
         // Hook: network:afterTeardown
         await this.hooks.callHook("network:afterTeardown", {
           vmId,
@@ -780,6 +785,14 @@ export class VMService {
         const stopResult = await this.stop(vmId);
         if (!stopResult.success) {
           return stopResult;
+        }
+      }
+
+      // Verify network cleanup
+      if (state.network) {
+        const leaks = verifyCleanup(state.network);
+        for (const leak of leaks) {
+          this.logger.warn(`[${vmId}] cleanup leak: ${leak}`);
         }
       }
 

--- a/tests/unit/kvm-check.test.ts
+++ b/tests/unit/kvm-check.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { accessSync, existsSync } from "node:fs";
+import { validateEnvironment } from "../../src/commands/create/environment.ts";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    accessSync: vi.fn(),
+  };
+});
+
+describe("validateEnvironment KVM check", () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset();
+    vi.mocked(accessSync).mockReset();
+  });
+
+  test("throws ERR_SETUP_KVM_UNAVAILABLE on missing KVM", () => {
+    // Firecracker and Jailer binaries exist
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    // /dev/kvm is not accessible
+    vi.mocked(accessSync).mockImplementation(() => {
+      throw new Error("EACCES: permission denied, access '/dev/kvm'");
+    });
+
+    try {
+      validateEnvironment("/fake/base");
+      expect.unreachable("should have thrown");
+    } catch (err: unknown) {
+      const error = err as { code: string };
+      expect(error.code).toBe("ERR_SETUP_KVM_UNAVAILABLE");
+    }
+  });
+});

--- a/tests/unit/network-cleanup.test.ts
+++ b/tests/unit/network-cleanup.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import type { VmNetwork } from "../../src/lib/vm-state.ts";
+import { verifyCleanup } from "../../src/lib/network.ts";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
+
+function makeNetwork(overrides?: Partial<VmNetwork>): VmNetwork {
+  return {
+    tapDevice: "fhvm0",
+    hostIp: "198.19.0.1",
+    guestIp: "198.19.0.2",
+    subnetMask: "255.255.255.252",
+    macAddress: "AA:FC:00:00:00:01",
+    networkPolicy: "allow-all",
+    allowedDomains: [],
+    allowedCidrs: [],
+    deniedCidrs: [],
+    publishedPorts: [],
+    tunnelHostname: null,
+    netnsName: "vmsan-test",
+    ...overrides,
+  };
+}
+
+describe("verifyCleanup", () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset();
+  });
+
+  test("detects orphaned TAP device", () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      if (String(p) === "/sys/class/net/fhvm0") return true;
+      return false;
+    });
+
+    const leaks = verifyCleanup(makeNetwork());
+    expect(leaks).toContain("TAP device fhvm0 still exists");
+  });
+
+  test("returns empty array for clean state", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const leaks = verifyCleanup(makeNetwork());
+    expect(leaks).toEqual([]);
+  });
+
+  test("detects orphaned namespace", () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      if (String(p) === "/var/run/netns/vmsan-test") return true;
+      return false;
+    });
+
+    const leaks = verifyCleanup(makeNetwork());
+    expect(leaks).toContain("Namespace vmsan-test still exists");
+  });
+
+  test("detects orphaned veth host device", () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      if (String(p) === "/sys/class/net/veth-h-0") return true;
+      return false;
+    });
+
+    const leaks = verifyCleanup(makeNetwork());
+    expect(leaks).toContain("Veth veth-h-0 still exists");
+  });
+
+  test("skips veth check when netnsName is absent", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const leaks = verifyCleanup(makeNetwork({ netnsName: undefined }));
+    // Should report TAP but not namespace or veth
+    expect(leaks).toContain("TAP device fhvm0 still exists");
+    expect(leaks).not.toContainEqual(expect.stringContaining("Veth"));
+    expect(leaks).not.toContainEqual(expect.stringContaining("Namespace"));
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/dev/kvm` accessibility check to `validateEnvironment()` with actionable error message
- Add `verifyCleanup()` to detect orphaned TAP devices, network namespaces, and veth interfaces after teardown
- Wire cleanup verification into `stop()` and `remove()` flows (warns on leaks, doesn't throw)

## Changes
- `src/commands/create/environment.ts` — KVM check in validateEnvironment()
- `src/errors/codes.ts` — new `ERR_SETUP_KVM_UNAVAILABLE` error code
- `src/errors/setup.ts` — new `kvmUnavailableError()` factory
- `src/errors/index.ts` — export new error factory
- `src/lib/network.ts` — new `verifyCleanup()` function
- `src/services/vm.ts` — call verifyCleanup() after teardown in stop/remove

## Test plan
- [x] `bun run test` — 13 tests pass
- [x] `bun run lint` — clean
- [ ] `vmsan create` on non-KVM machine shows clear error
- [ ] After `vmsan stop` + `vmsan remove`, no warnings about leaked resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KVM environment validation during setup with helpful troubleshooting guidance if KVM is unavailable on the system.
  * Implemented detection of residual network resources after VM stop and removal operations, with warnings logged for any cleanup issues.

* **Tests**
  * Added unit test coverage for KVM availability checks and network cleanup detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->