### PR TITLE
fix: audit and fix CLI help text

### DIFF
--- a/.changeset/cli-help-audit.md
+++ b/.changeset/cli-help-audit.md
@@ -1,0 +1,5 @@
+---
+"vmsan": patch
+---
+
+Audit and fix CLI help text for all commands

--- a/src/commands/create/args.ts
+++ b/src/commands/create/args.ts
@@ -20,7 +20,7 @@ export const createCommandArgs = {
   "from-image": {
     type: "string",
     description:
-      "Build rootfs from a Docker/OCI image (e.g. ubuntu:latest). Agent is not installed; connect, exec, upload/download unavailable.",
+      "Build rootfs from a Docker/OCI image (e.g. ubuntu:latest). Requires Docker. Agent is not installed; connect, exec, upload/download unavailable.",
   },
   runtime: {
     type: "string",
@@ -40,7 +40,7 @@ export const createCommandArgs = {
   },
   timeout: {
     type: "string",
-    description: "Auto-shutdown timeout (e.g. 1h, 30m, 2h30m)",
+    description: "Auto-shutdown timeout (e.g. 30s, 5m, 1h, 2h30m)",
   },
   "publish-port": {
     type: "string",


### PR DESCRIPTION
## Summary
- `--from-image`: add "Requires Docker." to description
- `--timeout`: add seconds example (30s) to format examples

## Changes
- `src/commands/create/args.ts` — two help text fixes

## Test plan
- [x] `bun run lint` — clean
- [ ] `vmsan create --help` shows updated descriptions