### PR TITLE
fix: skip veth cleanup check when namespace already deleted

### DIFF
--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -1079,11 +1079,14 @@ export function verifyCleanup(network: VmNetwork): string[] {
   if (existsSync(`/sys/class/net/${network.tapDevice}`)) {
     leaks.push(`TAP device ${network.tapDevice} still exists`);
   }
-  if (network.netnsName && existsSync(`/var/run/netns/${network.netnsName}`)) {
+  const nsExists = network.netnsName && existsSync(`/var/run/netns/${network.netnsName}`);
+  if (nsExists) {
     leaks.push(`Namespace ${network.netnsName} still exists`);
   }
+  // Only check veth if namespace still exists — when the namespace is deleted,
+  // the kernel auto-destroys the veth pair asynchronously
   const slot = slotFromVmHostIpOrNull(network.hostIp);
-  if (slot !== null && network.netnsName) {
+  if (slot !== null && nsExists) {
     const vethHost = `veth-h-${slot}`;
     if (existsSync(`/sys/class/net/${vethHost}`)) {
       leaks.push(`Veth ${vethHost} still exists`);

--- a/tests/unit/network-cleanup.test.ts
+++ b/tests/unit/network-cleanup.test.ts
@@ -61,14 +61,28 @@ describe("verifyCleanup", () => {
     expect(leaks).toContain("Namespace vmsan-test still exists");
   });
 
-  test("detects orphaned veth host device", () => {
+  test("detects orphaned veth when namespace also still exists", () => {
     vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/var/run/netns/vmsan-test") return true;
+      if (s === "/sys/class/net/veth-h-0") return true;
+      return false;
+    });
+
+    const leaks = verifyCleanup(makeNetwork());
+    expect(leaks).toContain("Namespace vmsan-test still exists");
+    expect(leaks).toContain("Veth veth-h-0 still exists");
+  });
+
+  test("skips veth check when namespace is already gone (kernel auto-cleans)", () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      // Namespace gone, but veth-h still briefly visible (kernel race)
       if (String(p) === "/sys/class/net/veth-h-0") return true;
       return false;
     });
 
     const leaks = verifyCleanup(makeNetwork());
-    expect(leaks).toContain("Veth veth-h-0 still exists");
+    expect(leaks).not.toContainEqual(expect.stringContaining("Veth"));
   });
 
   test("skips veth check when netnsName is absent", () => {


### PR DESCRIPTION
## Summary
- Skip veth host device check in `verifyCleanup()` when the network namespace is already gone
- When a namespace is deleted, the kernel auto-destroys the veth pair asynchronously — checking immediately after produces false-positive warnings

## Changes
- `src/lib/network.ts` — only check veth-h if namespace still exists
- `tests/unit/network-cleanup.test.ts` — add test for kernel race case, update existing veth test

## Test plan
- [x] `bun run test` — 180 tests pass
- [x] `bun run lint` — clean
- [ ] `vmsan stop` + `vmsan remove` no longer warns about veth on KVM server