### PR TITLE
chore: release 0.1.0-beta.1

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,12 +1,16 @@
 {
   "mode": "pre",
-  "tag": "alpha",
+  "tag": "beta",
   "initialVersions": {
-    "vmsan": "0.1.0-alpha.24"
+    "vmsan": "0.1.0-alpha.27"
   },
   "changesets": [
+    "cli-help-audit",
     "fix-loop-device-install",
+    "kvm-preflight-cleanup",
     "late-pianos-help",
-    "tidy-chairs-juggle"
+    "state-versioning",
+    "tidy-chairs-juggle",
+    "unit-tests-slot-hardening"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # vmsan
 
+## 0.1.0-beta.1
+
+### Minor Changes
+
+- [#47](https://github.com/angelorc/vmsan/pull/47) [`bfc12a7`](https://github.com/angelorc/vmsan/commit/bfc12a795ff2c4024b60a2df624c140e86c3806a) Thanks [@angelorc](https://github.com/angelorc)! - Add KVM pre-flight check to `vmsan create` and cleanup verification after `vmsan stop`/`vmsan remove`
+
+- [#46](https://github.com/angelorc/vmsan/pull/46) [`913e721`](https://github.com/angelorc/vmsan/commit/913e72150acbb449ba8be345f580f78fd11c563f) Thanks [@angelorc](https://github.com/angelorc)! - Add state file versioning to VM state store for future migration support
+
+### Patch Changes
+
+- [#48](https://github.com/angelorc/vmsan/pull/48) [`c824d44`](https://github.com/angelorc/vmsan/commit/c824d44c7961808ec08c965cfa87f94a5fb164c6) Thanks [@angelorc](https://github.com/angelorc)! - Audit and fix CLI help text for all commands
+
+- [#49](https://github.com/angelorc/vmsan/pull/49) [`cab910a`](https://github.com/angelorc/vmsan/commit/cab910a2a07f374892362af4f227e1c8d9d2f245) Thanks [@angelorc](https://github.com/angelorc)! - Add comprehensive unit test suite and reduce stale lock timeout from 5m to 30s
+
 ## 0.1.0-alpha.27
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vmsan",
-  "version": "0.1.0-alpha.27",
+  "version": "0.1.0-beta.1",
   "description": "Firecracker microVM sandbox toolkit",
   "homepage": "https://github.com/angelorc/vmsan",
   "bugs": "https://github.com/angelorc/vmsan/issues",


### PR DESCRIPTION
## Summary
- Transition from alpha to beta pre-release mode
- Version bump to `0.1.0-beta.1`
- Changelog generated for all Phase 1 changes

## What's in beta.1

### Minor Changes
- KVM pre-flight check + cleanup verification (#47)
- State file versioning (#46)

### Patch Changes  
- CLI help text audit (#48)
- Comprehensive unit test suite + slot lock hardening (#49)
- Veth cleanup race fix (#51)

## Test plan
- [x] All 180 unit tests pass
- [x] Go agent tests pass
- [x] All features validated on KVM server (46.101.108.83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.0-beta.1, transitioning from alpha to beta stage. Release documentation and pre-release configuration updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->