### PR TITLE
chore: release 0.1.0-beta.2

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,7 +5,10 @@
     "vmsan": "0.1.0-alpha.27"
   },
   "changesets": [
+    "bright-clouds-dance",
     "cli-help-audit",
+    "docs-beta2-sync",
+    "e2e-smoke-tests",
     "fix-loop-device-install",
     "kvm-preflight-cleanup",
     "late-pianos-help",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # vmsan
 
+## 0.1.0-beta.2
+
+### Minor Changes
+
+- [#56](https://github.com/angelorc/vmsan/pull/56) [`07ac73b`](https://github.com/angelorc/vmsan/commit/07ac73b578e3cb96bc1504390ab905ff00dc08c9) Thanks [@angelorc](https://github.com/angelorc)! - feat: add `vmsan doctor` diagnostic command and fix JSON output consistency
+
+### Patch Changes
+
+- [#55](https://github.com/angelorc/vmsan/pull/55) [`0899f7f`](https://github.com/angelorc/vmsan/commit/0899f7fee2ee18ffa7346612bf41756479764ac7) Thanks [@angelorc](https://github.com/angelorc)! - docs: sync documentation with beta.1 CLI changes
+
+- [#54](https://github.com/angelorc/vmsan/pull/54) [`d518f9a`](https://github.com/angelorc/vmsan/commit/d518f9a8a917285e373cf2b2adbbd56d8f6e5235) Thanks [@angelorc](https://github.com/angelorc)! - test: add e2e smoke test script and manual test matrix
+
 ## 0.1.0-beta.1
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vmsan",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Firecracker microVM sandbox toolkit",
   "homepage": "https://github.com/angelorc/vmsan",
   "bugs": "https://github.com/angelorc/vmsan/issues",


### PR DESCRIPTION
## Summary

- Version bump to `0.1.0-beta.2`
- Changelog generated from changesets

### What's in beta.2 — "Paper Trail"

**New:**
- `vmsan doctor` — 8 diagnostic checks (KVM, binaries, images, disk, network)
- E2E smoke test script (7 scenarios)
- Manual test matrix

**Fixed:**
- `stop` and `remove` commands now have error handling
- `network` command JSON output uses evlog instead of raw console.log
- Documentation synced with all beta.1 CLI changes

**Docs:**
- Added `node24` runtime to all references
- Documented `--from-image` limitations and `--connect` mutual exclusivity
- Added `-d/--dest` flags for upload/download
- Added `--session` flag for connect
- Added `vmsan doctor` to CLI reference

### Verified on KVM server (165.22.77.194)

- 196/196 unit tests pass
- 3/3 Go agent test packages pass
- 7/7 smoke tests pass
- 8/8 doctor checks pass
- Zero leaked resources

## Test plan

- [x] Unit tests: `bun run test` (196 pass)
- [x] Go tests: `cd agent && go test ./...` (3 pass)
- [x] Smoke tests: `sudo bash tests/e2e/smoke.sh` (7/7 on KVM)
- [x] `vmsan doctor` + `vmsan doctor --json`
- [x] CI pipeline validates on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vmsan doctor diagnostic command with improved JSON output support

* **Documentation**
  * Updated documentation synchronization

* **Tests**
  * Added end-to-end smoke test coverage

* **Chores**
  * Version bumped to 0.1.0-beta.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->