### PR TITLE
fix: use hoisted linker for docs build

### DIFF
--- a/.changeset/fix-docs-build-linker.md
+++ b/.changeset/fix-docs-build-linker.md
@@ -1,0 +1,5 @@
+---
+"vmsan": patch
+---
+
+fix: use hoisted linker for docs to work around @nuxt/content context isolation bug

--- a/docs/bunfig.toml
+++ b/docs/bunfig.toml
@@ -1,0 +1,5 @@
+# Use hoisted linker to avoid @nuxt/content context isolation bug
+# with bun's default isolated (pnpm-style) linker.
+# See: https://github.com/nuxt/content/issues/3547
+[install]
+linker = "hoisted"


### PR DESCRIPTION
## Summary

- Adds `bunfig.toml` to docs workspace with `linker = "hoisted"` to fix the build failure
- Bun's default isolated (pnpm-style) linker causes `@nuxt/content`'s internal context to be lost when `jiti` loads a separate module instance for docus's `content.config.ts`, resulting in a "Zod is not installed" error
- The hoisted linker ensures all packages share the same module instances, which is required for `@nuxt/content`'s context initialization to carry over to the `jiti`-loaded content config

Upstream issue: https://github.com/nuxt/content/issues/3547

## Test plan

- [x] `bun run build` in `docs/` succeeds with this change
- [ ] Verify docs deploy works in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation build configuration to resolve an issue preventing proper documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->