### PR TITLE
fix: include error code in JSON output

### DIFF
--- a/.changeset/fix-json-error-code.md
+++ b/.changeset/fix-json-error-code.md
@@ -1,0 +1,5 @@
+---
+"vmsan": patch
+---
+
+fix: include error code and fix/why fields at top level of JSON error output

--- a/src/errors/display.ts
+++ b/src/errors/display.ts
@@ -2,9 +2,24 @@ import { consola } from "consola";
 import { EvlogError } from "evlog";
 import type { CommandLogger } from "../lib/logger/index.ts";
 import { getOutputMode } from "../lib/logger/index.ts";
+import { VmsanError } from "./base.ts";
 
 export function handleCommandError(error: unknown, cmdLog: CommandLogger): void {
   cmdLog.error(error instanceof Error ? error : String(error));
+
+  // evlog's error() only serializes a fixed set of fields (name, message, stack,
+  // status, data, cause). Merge VmsanError-specific fields (code, fix) so they
+  // appear at the top level of the error object in --json output.
+  if (error instanceof VmsanError) {
+    const { name: _n, message: _m, status: _s, data: _d, cause: _c, ...extra } = error.toJSON();
+    if (Object.keys(extra).length > 0) {
+      cmdLog.set({ error: extra });
+    }
+    // Promote fix/why to the error top level so consumers don't need to dig into data
+    if (error.fix) cmdLog.set({ error: { fix: error.fix } });
+    if (error.why) cmdLog.set({ error: { why: error.why } });
+  }
+
   cmdLog.emit();
 
   // In JSON mode, cmdLog.emit() already produced structured error output.

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
+import { createLogger, initLogger } from "evlog";
 import { VmsanError } from "../../src/errors/base.ts";
 import { ValidationError } from "../../src/errors/validation.ts";
 import { VmError } from "../../src/errors/vm.ts";
 import { TimeoutError } from "../../src/errors/timeout.ts";
 import { FirecrackerApiError } from "../../src/errors/firecracker.ts";
 import { CloudflareError } from "../../src/errors/cloudflare.ts";
+import { handleCommandError } from "../../src/errors/display.ts";
+import type { CommandLogger } from "../../src/lib/logger/index.ts";
 import {
   invalidIntegerFlagError,
   invalidRuntimeError,
@@ -274,5 +277,98 @@ describe("toJSON", () => {
     const err = cloudflareNoZoneError("example.com");
     const json = err.toJSON();
     expect(json.domain).toBe("example.com");
+  });
+});
+
+// ---------- handleCommandError JSON enrichment ----------
+
+describe("handleCommandError JSON enrichment", () => {
+  beforeEach(() => {
+    // Enable evlog so createLogger returns a real logger with getContext()
+    initLogger({ enabled: true, pretty: false, stringify: false });
+  });
+
+  function createTestCmdLog(): CommandLogger & { getContext: () => Record<string, unknown> } {
+    const logger = createLogger({ path: "test" });
+    return {
+      set: logger.set.bind(logger),
+      error: logger.error.bind(logger),
+      emit: () => {},
+      getContext: logger.getContext.bind(logger),
+    };
+  }
+
+  it("includes error code in logger context for VmsanError", () => {
+    const cmdLog = createTestCmdLog();
+    const err = vmNotFoundError("vm-1");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.code).toBe("ERR_VM_NOT_FOUND");
+  });
+
+  it("includes vmId in logger context for VmError", () => {
+    const cmdLog = createTestCmdLog();
+    const err = vmNotFoundError("vm-1");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.vmId).toBe("vm-1");
+  });
+
+  it("includes flag in logger context for ValidationError", () => {
+    const cmdLog = createTestCmdLog();
+    const err = invalidPortError("bad");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.flag).toBe("publish-port");
+  });
+
+  it("promotes fix to error top level", () => {
+    const cmdLog = createTestCmdLog();
+    const err = vmNotFoundError("vm-1");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.fix).toBe("Run 'vmsan list' to see available VMs.");
+  });
+
+  it("promotes why to error top level", () => {
+    const cmdLog = createTestCmdLog();
+    const err = chrootNotFoundError("vm-1");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.why).toBe("The VM data may have been removed.");
+  });
+
+  it("preserves standard error fields (name, message, status)", () => {
+    const cmdLog = createTestCmdLog();
+    const err = vmNotFoundError("vm-1");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.name).toBe("VmError");
+    expect(error.message).toContain("vm-1");
+    expect(error.status).toBe(500);
+  });
+
+  it("does not add extra fields for non-VmsanError errors", () => {
+    const cmdLog = createTestCmdLog();
+    const err = new Error("generic error");
+    handleCommandError(err, cmdLog);
+
+    const ctx = cmdLog.getContext();
+    const error = ctx.error as Record<string, unknown>;
+    expect(error.name).toBe("Error");
+    expect(error.message).toBe("generic error");
+    expect(error).not.toHaveProperty("code");
   });
 });


### PR DESCRIPTION
## Summary
- Enriches the `--json` error envelope with VmsanError-specific fields (`code`, `vmId`, `flag`, etc.) that evlog's `error()` method does not serialize by default
- Promotes `fix` and `why` to the top level of the error object so consumers don't need to dig into `error.data`
- Adds 7 unit tests verifying the JSON enrichment behavior

## Test plan
- [x] All new `handleCommandError JSON enrichment` tests pass (7/7)
- [x] All existing error tests still pass (24/24)
- [x] TypeScript typecheck passes
- [x] Lint/format clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON error output format to include error codes and fix/why fields at the top level, improving error diagnosis and troubleshooting by making critical information more accessible without requiring nested data inspection.

* **Tests**
  * Added comprehensive test coverage for the new JSON error output enrichment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->